### PR TITLE
Correctly calculate string length based on encoded length

### DIFF
--- a/qpython/qwriter.py
+++ b/qpython/qwriter.py
@@ -165,10 +165,12 @@ class QWriter(object):
         if not self._options.single_char_strings and len(data) == 1:
             self._write_atom(ord(data), QCHAR)
         else:
-            self._buffer.write(struct.pack('=bxi', QSTRING, len(data)))
             if isinstance(data, str):
-                self._buffer.write(data.encode(self._encoding))
+                encoded_data = data.encode(self._encoding)
+                self._buffer.write(struct.pack('=bxi', QSTRING, len(encoded_data)))
+                self._buffer.write(encoded_data)
             else:
+                self._buffer.write(struct.pack('=bxi', QSTRING, len(data)))
                 self._buffer.write(data)
 
 


### PR DESCRIPTION
The current implementation calculates the length of the string to send by simply using len() on the string. However, the correct calculation (that kdb expects) is the length of the encoded string.

In latin-1 and ascii, these two are the same. However for extended characters such as those in the utf-8 char-set, a single character in a python string may be 2 or more encoded characters. Since QConnection now supports passing alternate encoding parameters, e.g. utf-8, this should be supported here as well -- otherwise qPython reports an error when trying to send extended chars.

E.g.:
qcon = qpython.qconnection.QConnection(host = Host, port = Port, username = User, password = Pass, encoding = 'UTF-8')

This PR replicates the one from https://github.com/exxeleron/qPython/pull/77

In addition, this change has been in use in sublime-q since 2020.