### PR TITLE
adding TLS support, optional custom CA path param, making comaptible …

### DIFF
--- a/qpython/qcollection.py
+++ b/qpython/qcollection.py
@@ -378,9 +378,9 @@ def qtable(columns, data, **meta):
         
         if isinstance(data[i], str):
             # convert character list (represented as string) to numpy representation
-            data[i] = numpy.array(list(data[i]), dtype = numpy.string_)
+            data[i] = numpy.array(list(data[i]), dtype = numpy.bytes_)
         if isinstance(data[i], bytes):
-            data[i] = numpy.array(list(data[i].decode()), dtype = numpy.string_)
+            data[i] = numpy.array(list(data[i].decode()), dtype = numpy.bytes_)
 
         if column_name in meta:
             data[i] = qlist(data[i], qtype = meta[column_name])

--- a/qpython/qreader.py
+++ b/qpython/qreader.py
@@ -248,7 +248,7 @@ class QReader(object):
 
     @parse(QSYMBOL)
     def _read_symbol(self, qtype = QSYMBOL):
-        return numpy.string_(self._buffer.get_symbol())
+        return numpy.bytes_(self._buffer.get_symbol())
 
 
     @parse(QCHAR)
@@ -289,7 +289,7 @@ class QReader(object):
 
         if qtype == QSYMBOL_LIST:
             symbols = self._buffer.get_symbols(length)
-            data = numpy.array(symbols, dtype = numpy.string_)
+            data = numpy.array(symbols, dtype = numpy.bytes_)
             return qlist(data, qtype = qtype, adjust_dtype = False)
         elif qtype == QGUID_LIST:
             data = numpy.array([self._read_guid() for x in range(length)])
@@ -562,5 +562,4 @@ class QReader(object):
             self._position = new_position
 
             return raw.split(b'\x00')
-
 

--- a/qpython/qtype.py
+++ b/qpython/qtype.py
@@ -170,7 +170,7 @@ PY_TYPE = {
     QFLOAT:         numpy.float32,
     QDOUBLE:        numpy.float64,
     QCHAR:          numpy.byte,
-    QSYMBOL:        numpy.string_,
+    QSYMBOL:        numpy.bytes_,
     QMONTH:         numpy.int32,
     QDATE:          numpy.int32,
     QDATETIME:      numpy.float64,
@@ -199,7 +199,7 @@ Q_TYPE = {
     numpy.float64    : QDOUBLE,
     str              : QSTRING,
     bytes            : QSTRING,
-    numpy.string_    : QSYMBOL,
+    numpy.bytes_     : QSYMBOL,
     uuid.UUID        : QGUID,
     }
 
@@ -261,7 +261,7 @@ _QNULL8 = numpy.int64(-2**63)
 _QNAN32 = numpy.frombuffer(b'\x00\x00\xc0\x7f', dtype=numpy.float32)[0]
 _QNAN64 = numpy.frombuffer(b'\x00\x00\x00\x00\x00\x00\xf8\x7f', dtype=numpy.float64)[0]
 _QNULL_BOOL = numpy.bool_(False)
-_QNULL_SYM = numpy.string_('')
+_QNULL_SYM = numpy.bytes_('')
 _QNULL_GUID = uuid.UUID('00000000-0000-0000-0000-000000000000')
 
 

--- a/qpython/qwriter.py
+++ b/qpython/qwriter.py
@@ -172,7 +172,7 @@ class QWriter(object):
                 self._buffer.write(data)
 
 
-    @serialize(numpy.string_)
+    @serialize(numpy.bytes_)
     def _write_symbol(self, data):
         self._buffer.write(struct.pack('=b', QSYMBOL))
         if data:


### PR DESCRIPTION
…with new numpy version, put timeout on q.open() method as well

THE FOLLOWING DISCLAIMER APPLIES TO ALL SOFTWARE CODE AND OTHER MATERIALS CONTRIBUTED IN CONNECTION WITH THIS SOFTWARE:
THIS SOFTWARE IS LICENSED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE AND ANY WARRANTY OF NON-INFRINGEMENT, ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. THIS SOFTWARE MAY BE REDISTRIBUTED TO OTHERS ONLY BY EFFECTIVELY USING THIS OR ANOTHER EQUIVALENT DISCLAIMER IN ADDITION TO ANY OTHER REQUIRED LICENSE TERMS.
ONLY THE SOFTWARE CODE AND OTHER MATERIALS CONTRIBUTED IN CONNECTION WITH THIS SOFTWARE, IF ANY, THAT ARE ATTACHED TO (OR OTHERWISE ACCOMPANY) THIS SUBMISSION (AND ORDINARY COURSE CONTRIBUTIONS OF FUTURES PATCHES THERETO) ARE TO BE CONSIDERED A CONTRIBUTION. NO OTHER SOFTWARE CODE OR MATERIALS ARE A CONTRIBUTION.
